### PR TITLE
Pass environment in getProperty(String) call.

### DIFF
--- a/src/main/java/org/cfg4j/provider/SimpleConfigurationProvider.java
+++ b/src/main/java/org/cfg4j/provider/SimpleConfigurationProvider.java
@@ -64,7 +64,7 @@ public class SimpleConfigurationProvider implements ConfigurationProvider {
   public String getProperty(String key) {
     try {
 
-      String property = configurationSource.getConfiguration().getProperty(key);
+      String property = configurationSource.getConfiguration(environment).getProperty(key);
 
       if (property == null) {
         throw new NoSuchElementException("No configuration with key: " + key);

--- a/src/test/java/org/cfg4j/provider/SimpleConfigurationProviderAbstractTest.java
+++ b/src/test/java/org/cfg4j/provider/SimpleConfigurationProviderAbstractTest.java
@@ -26,6 +26,8 @@ import org.cfg4j.source.context.Environment;
 
 import java.util.Properties;
 
+import static org.mockito.Matchers.any;
+
 @RunWith(MockitoJUnitRunner.class)
 public abstract class SimpleConfigurationProviderAbstractTest {
 
@@ -52,5 +54,9 @@ public abstract class SimpleConfigurationProviderAbstractTest {
     }
 
     return properties;
+  }
+
+  protected Environment anyEnvironment() {
+    return any(Environment.class);
   }
 }

--- a/src/test/java/org/cfg4j/provider/SimpleConfigurationProviderBindTest.java
+++ b/src/test/java/org/cfg4j/provider/SimpleConfigurationProviderBindTest.java
@@ -39,7 +39,7 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void bindShouldThrowWhenFetchingNonexistentKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(new Properties());
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(new Properties());
 
     expectedException.expect(NoSuchElementException.class);
     simpleConfigurationProvider.bind("", ConfigPojo.class);
@@ -47,7 +47,7 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void bindShouldThrowWhenUnableToFetchKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenThrow(IllegalStateException.class);
+    when(configurationSource.getConfiguration(anyEnvironment())).thenThrow(IllegalStateException.class);
 
     expectedException.expect(IllegalStateException.class);
     simpleConfigurationProvider.bind("", ConfigPojo.class);
@@ -55,7 +55,7 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void bindShouldThrowOnIncompatibleConversion() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("someSetting", "shouldBeNumber"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("someSetting", "shouldBeNumber"));
 
     expectedException.expect(IllegalArgumentException.class);
     simpleConfigurationProvider.bind("", ConfigPojo.class);
@@ -63,7 +63,7 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void shouldBindAllInterfaceMethods() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("someSetting", "42", "otherSetting", "true,false"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("someSetting", "42", "otherSetting", "true,false"));
 
     MultiPropertyConfigPojo config = simpleConfigurationProvider.bind("", MultiPropertyConfigPojo.class);
     assertThat(config.someSetting()).isEqualTo(42);
@@ -72,7 +72,7 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void shouldBindInitialValues() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("someSetting", "42"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("someSetting", "42"));
 
     ConfigPojo config = simpleConfigurationProvider.bind("", ConfigPojo.class);
     assertThat(config.someSetting()).isEqualTo(42);
@@ -80,7 +80,7 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void shouldBindInitialValuesInSubPath() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("myContext.someSetting", "42"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("myContext.someSetting", "42"));
 
     ConfigPojo config = simpleConfigurationProvider.bind("myContext", ConfigPojo.class);
     assertThat(config.someSetting()).isEqualTo(42);
@@ -88,10 +88,10 @@ public class SimpleConfigurationProviderBindTest extends SimpleConfigurationProv
 
   @Test
   public void shouldReactToSourceChanges() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("someSetting", "42"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("someSetting", "42"));
     ConfigPojo config = simpleConfigurationProvider.bind("", ConfigPojo.class);
 
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("someSetting", "0"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("someSetting", "0"));
 
     assertThat(config.someSetting()).isEqualTo(0);
   }

--- a/src/test/java/org/cfg4j/provider/SimpleConfigurationProviderGetPropertyTest.java
+++ b/src/test/java/org/cfg4j/provider/SimpleConfigurationProviderGetPropertyTest.java
@@ -16,11 +16,10 @@
 package org.cfg4j.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.cfg4j.source.context.Environment;
+import org.cfg4j.source.context.ImmutableEnvironment;
 import org.cfg4j.source.context.MissingEnvironmentException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +34,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void allConfigurationAsPropertiesShouldThrowWhenUnableToFetchConfiguration() throws Exception {
-    when(configurationSource.getConfiguration(any(Environment.class))).thenThrow(IllegalStateException.class);
+    when(configurationSource.getConfiguration(anyEnvironment())).thenThrow(IllegalStateException.class);
 
     expectedException.expect(IllegalStateException.class);
     simpleConfigurationProvider.allConfigurationAsProperties();
@@ -43,7 +42,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void allConfigurationAsPropertiesShouldThrowWhenMissingEnvironment() throws Exception {
-    when(configurationSource.getConfiguration(any(Environment.class))).thenThrow(MissingEnvironmentException.class);
+    when(configurationSource.getConfiguration(anyEnvironment())).thenThrow(MissingEnvironmentException.class);
 
     expectedException.expect(IllegalStateException.class);
     simpleConfigurationProvider.allConfigurationAsProperties();
@@ -51,7 +50,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void allConfigurationAsPropertiesShouldUseProvidedEnvironment() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(new Properties());
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(new Properties());
 
     simpleConfigurationProvider.allConfigurationAsProperties();
 
@@ -60,7 +59,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getPropertyShouldThrowWhenFetchingNonexistentKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(new Properties());
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(new Properties());
 
     expectedException.expect(NoSuchElementException.class);
     simpleConfigurationProvider.getProperty("some.property");
@@ -68,7 +67,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getPropertyShouldThrowWhenUnableToFetchKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenThrow(IllegalStateException.class);
+    when(configurationSource.getConfiguration(anyEnvironment())).thenThrow(IllegalStateException.class);
 
     expectedException.expect(IllegalStateException.class);
     simpleConfigurationProvider.getProperty("some.property");
@@ -76,7 +75,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getPropertyShouldReturnStringPropertyFromSource() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "abc"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "abc"));
 
     String property = simpleConfigurationProvider.getProperty("some.property");
     assertThat(property).isEqualTo("abc");
@@ -84,8 +83,8 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getPropertyShouldReactToSourceChanges() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "abc"));
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "cde"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "abc"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "cde"));
 
     String property = simpleConfigurationProvider.getProperty("some.property");
     assertThat(property).isEqualTo("cde");
@@ -93,7 +92,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty2ShouldThrowWhenFetchingNonexistentKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(new Properties());
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(new Properties());
 
     expectedException.expect(NoSuchElementException.class);
     simpleConfigurationProvider.getProperty("some.property", String.class);
@@ -101,7 +100,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty2ShouldThrowWhenUnableToFetchKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenThrow(IllegalStateException.class);
+    when(configurationSource.getConfiguration(anyEnvironment())).thenThrow(IllegalStateException.class);
 
     expectedException.expect(IllegalStateException.class);
     simpleConfigurationProvider.getProperty("some.property", String.class);
@@ -109,7 +108,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty2ShouldThrowOnIncompatibleConversion() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "true"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "true"));
 
     expectedException.expect(IllegalArgumentException.class);
     simpleConfigurationProvider.getProperty("some.property", Integer.class);
@@ -117,7 +116,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty2ShouldReturnPropertyFromSource() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "true"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "true"));
 
     Boolean property = simpleConfigurationProvider.getProperty("some.property", Boolean.class);
     assertThat(property).isTrue();
@@ -125,8 +124,8 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty2ShouldReactToSourceChanges() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "true"));
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "false"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "true"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "false"));
 
     Boolean property = simpleConfigurationProvider.getProperty("some.property", Boolean.class);
     assertThat(property).isFalse();
@@ -134,7 +133,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty2ShouldReturnArrayPropertyFromSource() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "42.5, 99.9999"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "42.5, 99.9999"));
 
     double[] property = simpleConfigurationProvider.getProperty("some.property", double[].class);
     assertThat(property).containsExactly(42.5, 99.9999);
@@ -142,7 +141,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty3ShouldThrowWhenFetchingNonexistentKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(new Properties());
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(new Properties());
 
     expectedException.expect(NoSuchElementException.class);
     simpleConfigurationProvider.getProperty("some.property", new GenericType<List<String>>() {
@@ -151,7 +150,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty3ShouldThrowWhenUnableToFetchKey() throws Exception {
-    when(configurationSource.getConfiguration()).thenThrow(IllegalStateException.class);
+    when(configurationSource.getConfiguration(anyEnvironment())).thenThrow(IllegalStateException.class);
 
     expectedException.expect(IllegalStateException.class);
     simpleConfigurationProvider.getProperty("some.property", new GenericType<List<String>>() {
@@ -160,7 +159,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty3ShouldThrowOnIncompatibleConversion() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "true"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "true"));
 
     expectedException.expect(IllegalArgumentException.class);
     simpleConfigurationProvider.getProperty("some.property", new GenericType<List<Integer>>() {
@@ -169,7 +168,7 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty3ShouldReturnPropertyFromSource() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "1,2"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "1,2"));
 
     List<Integer> properties = simpleConfigurationProvider.getProperty("some.property", new GenericType<List<Integer>>() {
     });
@@ -178,12 +177,22 @@ public class SimpleConfigurationProviderGetPropertyTest extends SimpleConfigurat
 
   @Test
   public void getProperty3ShouldReactToSourceChanges() throws Exception {
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "1,2"));
-    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "3,4,5"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "1,2"));
+    when(configurationSource.getConfiguration(anyEnvironment())).thenReturn(propertiesWith("some.property", "3,4,5"));
 
     List<Integer> properties = simpleConfigurationProvider.getProperty("some.property", new GenericType<List<Integer>>() {
     });
     assertThat(properties).containsExactly(3,4,5);
   }
 
+  @Test
+  public void getPropertyShouldReturnPropertyForProperEnvironment() throws Exception {
+    when(configurationSource.getConfiguration(environment)).thenReturn(propertiesWith("some.property", "1"));
+    when(configurationSource.getConfiguration(new ImmutableEnvironment("test_env"))).thenReturn(propertiesWith("some.property", "2"));
+    when(configurationSource.getConfiguration()).thenReturn(propertiesWith("some.property", "3"));
+
+    Integer property = simpleConfigurationProvider.getProperty("some.property", Integer.class);
+
+    assertThat(property).isEqualTo(1);
+  }
 }


### PR DESCRIPTION
Fixes cfg4j/cfg4j#64