### PR TITLE
Fix consul value fetch

### DIFF
--- a/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSource.java
+++ b/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSource.java
@@ -17,6 +17,7 @@ package org.cfg4j.source.consul;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.net.HostAndPort;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.model.kv.Value;
@@ -97,7 +98,8 @@ class ConsulConfigurationSource implements ConfigurationSource {
     try {
       LOG.info("Connecting to Consul client at " + host + ":" + port);
 
-      Consul consul = Consul.newClient(host, port);
+      Consul consul =  Consul.builder().withHostAndPort(HostAndPort.fromParts(host,port)).build();
+
       kvClient = consul.keyValueClient();
     } catch (Exception e) {
       throw new SourceCommunicationException("Can't connect to host " + host + ":" + port, e);

--- a/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSourceBuilder.java
+++ b/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSourceBuilder.java
@@ -15,6 +15,9 @@
  */
 package org.cfg4j.source.consul;
 
+import org.cfg4j.source.context.environment.Environment;
+import org.cfg4j.source.context.environment.ImmutableEnvironment;
+
 /**
  * Builder for {@link ConsulConfigurationSource}.
  */
@@ -22,6 +25,7 @@ public class ConsulConfigurationSourceBuilder {
 
   private String host;
   private int port;
+  private Environment environment;
 
   /**
    * Construct {@link ConsulConfigurationSource}s builder
@@ -35,6 +39,7 @@ public class ConsulConfigurationSourceBuilder {
   public ConsulConfigurationSourceBuilder() {
     host = "localhost";
     port = 8500;
+    environment = new ImmutableEnvironment("/");
   }
 
   /**
@@ -60,12 +65,23 @@ public class ConsulConfigurationSourceBuilder {
   }
 
   /**
+   * Set the {@link Environment} to use as your Consul Key Prefix root for configuration.
+   *
+   * @param environment a {@link Environment} interpreted as a Consul Key Prefix
+   * @return this builder with the Environment set to the provided Environment
+     */
+  public ConsulConfigurationSourceBuilder withEnvironment(Environment environment) {
+    this.environment = environment;
+    return this;
+  }
+
+  /**
    * Build a {@link ConsulConfigurationSource} using this builder's configuration
    *
    * @return new {@link ConsulConfigurationSource}
    */
   public ConsulConfigurationSource build() {
-    return new ConsulConfigurationSource(host, port);
+    return new ConsulConfigurationSource(host, port,environment);
   }
 
   @Override
@@ -73,6 +89,7 @@ public class ConsulConfigurationSourceBuilder {
     return "ConsulConfigurationSource{" +
         "host=" + host +
         ", port=" + port +
+        ", environment=" + environment +
         '}';
   }
 }

--- a/cfg4j-consul/src/test/java/org/cfg4j/source/consul/ConsulConfigurationSourceIntegrationTest.java
+++ b/cfg4j-consul/src/test/java/org/cfg4j/source/consul/ConsulConfigurationSourceIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
@@ -50,6 +51,11 @@ public class ConsulConfigurationSourceIntegrationTest {
     private static final String disabledBase64 = "ZGlzYWJsZWQ=";
     private static final String enabledBase64 = "ZW5hYmxlZA==";
 
+    private static final String usWest1Config = "{\"CreateIndex\":1,\"ModifyIndex\":1,\"LockIndex\":0,\"Key\":\"us-west-1/featureA.toggle\",\"Flags\":0,\"Value\":\"" + disabledBase64 + "\"}";
+    private static final String usWest2FeatureEnable = "{\"CreateIndex\":2,\"ModifyIndex\":2,\"LockIndex\":0,\"Key\":\"us-west-2/featureB.toggle\",\"Flags\":0,\"Value\":\"" + enabledBase64 + "\"}";
+    private static final String usWest2FeatureDisabled = "{\"CreateIndex\":2,\"ModifyIndex\":2,\"LockIndex\":0,\"Key\":\"us-west-2/featureB.toggle\",\"Flags\":0,\"Value\":\"" + disabledBase64 + "\"}";
+
+
     private boolean usWest2Toggle = false;
 
     void toggleUsWest2() {
@@ -58,17 +64,30 @@ public class ConsulConfigurationSourceIntegrationTest {
 
     @Override
     public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
-
+      StringBuilder sbResponseBody = new StringBuilder();
       switch (request.getPath()) {
         case "/v1/agent/self":
           return new MockResponse().setResponseCode(200).setBody(PING_RESPONSE);
         case "/v1/kv/?recurse=true":
+          sbResponseBody.append("[");
+          sbResponseBody.append(usWest1Config).append(",");
+          if(usWest2Toggle) {
+            sbResponseBody.append(usWest2FeatureEnable);
+          } else {
+            sbResponseBody.append(usWest2FeatureDisabled);
+          }
+          sbResponseBody.append("]");
+
           return new MockResponse()
               .setResponseCode(200)
               .addHeader("Content-Type", "application/json; charset=utf-8")
-              .setBody("[{\"CreateIndex\":1,\"ModifyIndex\":1,\"LockIndex\":0,\"Key\":\"us-west-1/featureA.toggle\",\"Flags\":0,\"Value\":\"ZGlzYWJsZWQ=\"},"
-                  + "{\"CreateIndex\":2,\"ModifyIndex\":2,\"LockIndex\":0,\"Key\":\"us-west-2/featureA.toggle\",\"Flags\":0,\"Value\":\""
-                  + (usWest2Toggle ? enabledBase64 : disabledBase64) + "\"}]");
+              .setBody(sbResponseBody.toString());
+
+        case "/v1/kv/us-west-1?recurse=true":
+          return new MockResponse()
+                  .setResponseCode(200)
+                  .addHeader("Content-Type", "application/json; charset=utf-8")
+                  .setBody("[" + usWest1Config + "]");
       }
       return new MockResponse().setResponseCode(404);
     }
@@ -131,13 +150,31 @@ public class ConsulConfigurationSourceIntegrationTest {
   }
 
   @Test
+  public void getConfigurationWithSourceEnvironmentSetShouldReturnOnlyKeysInEnvironment() throws Exception {
+    Environment environment = new ImmutableEnvironment("/us-west-1");
+
+    ConsulConfigurationSource source = new ConsulConfigurationSourceBuilder()
+            .withHost(server.getHostName())
+            .withPort(server.getPort())
+            .withEnvironment(environment)
+            .build();
+
+    source.init();
+
+    // Match with any prefix, we shouldn't have gotten us-west-2 data back
+    assertThat(source.getConfiguration(() -> "")).doesNotContain(MapEntry.entry("featureB.toggle", "disabled"));
+
+    assertThat(source.getConfiguration(environment)).contains(MapEntry.entry("featureA.toggle", "disabled"));
+  }
+
+  @Test
   public void getConfigurationShouldBeUpdatedByReload() throws Exception {
     dispatcher.toggleUsWest2();
 
     source.reload();
 
     Environment environment = new ImmutableEnvironment("us-west-2");
-    assertThat(source.getConfiguration(environment)).contains(MapEntry.entry("featureA.toggle", "enabled"));
+    assertThat(source.getConfiguration(environment)).contains(MapEntry.entry("featureB.toggle", "enabled"));
   }
 
   @Test


### PR DESCRIPTION
This is a proposed fix for the issue I raised in #144 

Here I choose to not change the contract provided by the [Reloadable](https://github.com/cfg4j/cfg4j/blob/v.4.2.1/cfg4j-core/src/main/java/org/cfg4j/source/reload/Reloadable.java) interface, since it wouldn't make sense in other contexts. 

Instead  in ConsulConfigurationSourceBuilder you can optionally provide an Environment which will be used to only fetch values given your Environment context instead of all of the values in Consul. If you don't provide an Environment it defaults back to it's old behavior.