### PR TITLE
Loading JAR classloader can’t lookup empty string

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
@@ -105,7 +105,7 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
     Path pathPrefix = Paths.get(environment.getName());
 
     URL url = getClass().getClassLoader().getResource(pathPrefix.toString());
-    if (url == null) {
+    if (url == null && !environment.getName().isEmpty()) {
       throw new MissingEnvironmentException("Directory doesn't exist: " + environment.getName());
     }
 


### PR DESCRIPTION
If a classpath configuration file is being loaded from inside a JAR then before attempting to load the configuration files it checks that the environment exists, however when a JAR class loader is being used the lookup for an empty environment returns null and so if fails, complaining that the environment can’t be found.

Fixes #154