### PR TITLE
property keys separator

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
@@ -70,9 +70,7 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
    * @param configFilesProvider {@link ConfigFilesProvider} supplying a list of configuration files to use
    */
   public ClasspathConfigurationSource(ConfigFilesProvider configFilesProvider) {
-    this(configFilesProvider, new PropertiesProviderSelector(
-        new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
-    ));
+    this(configFilesProvider, PropertiesProviderSelector.createDefault());
   }
 
   /**

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/FormatBasedPropertiesProvider.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/FormatBasedPropertiesProvider.java
@@ -23,6 +23,12 @@ import java.util.Map;
 
 abstract class FormatBasedPropertiesProvider implements PropertiesProvider {
 
+  private final String keySeparator;
+
+  public FormatBasedPropertiesProvider(String keySeparator) {
+    this.keySeparator = keySeparator;
+  }
+
   /**
    * Flatten multi-level map.
    */
@@ -37,7 +43,7 @@ abstract class FormatBasedPropertiesProvider implements PropertiesProvider {
         Map<String, Object> subMap = flatten((Map<String, Object>) value);
 
         for (String subkey : subMap.keySet()) {
-          result.put(key + "." + subkey, subMap.get(subkey));
+          result.put(key + keySeparator + subkey, subMap.get(subkey));
         }
       } else if (value instanceof Collection) {
         StringBuilder joiner = new StringBuilder();

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/JsonBasedPropertiesProvider.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/JsonBasedPropertiesProvider.java
@@ -33,6 +33,14 @@ import java.util.Properties;
  */
 public class JsonBasedPropertiesProvider extends FormatBasedPropertiesProvider {
 
+  public JsonBasedPropertiesProvider() {
+    super(DEFAULT_SEPARATOR);
+  }
+
+  public JsonBasedPropertiesProvider(String keySeparator) {
+    super(keySeparator);
+  }
+
   /**
    * Get {@link Properties} for a given {@code inputStream} treating it as a JSON file.
    *

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/PropertiesProvider.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/PropertiesProvider.java
@@ -24,6 +24,8 @@ import java.util.Properties;
  */
 public interface PropertiesProvider {
 
+  String DEFAULT_SEPARATOR = ".";
+
   /**
    * Get {@link Properties} for a given {@code inputStream}.
    *

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/PropertiesProviderSelector.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/PropertiesProviderSelector.java
@@ -27,6 +27,18 @@ public class PropertiesProviderSelector {
   private final PropertiesProvider jsonProvider;
   private final PropertiesProvider propertiesProvider;
 
+  public static PropertiesProviderSelector createDefault() {
+    return new PropertiesProviderSelector(
+      new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
+    );
+  }
+
+  public static PropertiesProviderSelector createWithSeparator(String separator) {
+    return new PropertiesProviderSelector(
+      new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(separator), new JsonBasedPropertiesProvider(separator)
+    );
+  }
+
   /**
    * Construct selector.
    *

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/YamlBasedPropertiesProvider.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/YamlBasedPropertiesProvider.java
@@ -36,6 +36,14 @@ import java.util.Properties;
  */
 public class YamlBasedPropertiesProvider extends FormatBasedPropertiesProvider {
 
+  public YamlBasedPropertiesProvider() {
+    super(DEFAULT_SEPARATOR);
+  }
+
+  public YamlBasedPropertiesProvider(String keySeparator) {
+    super(keySeparator);
+  }
+
   /**
    * Get {@link Properties} for a given {@code inputStream} treating it as a YAML file.
    *

--- a/cfg4j-core/src/main/java/org/cfg4j/source/files/FilesConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/files/FilesConfigurationSource.java
@@ -70,9 +70,7 @@ public class FilesConfigurationSource implements ConfigurationSource {
    * @param configFilesProvider {@link ConfigFilesProvider} supplying a list of configuration files to use
    */
   public FilesConfigurationSource(ConfigFilesProvider configFilesProvider) {
-    this(configFilesProvider, new PropertiesProviderSelector(
-        new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
-    ));
+    this(configFilesProvider, PropertiesProviderSelector.createDefault());
   }
 
   /**

--- a/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/JsonBasedPropertiesProviderTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/JsonBasedPropertiesProviderTest.java
@@ -47,7 +47,7 @@ public class JsonBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/JsonBasedPropertiesProviderTest_shouldReadSingleValues.json";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("setting", "masterValue"),
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("setting", "masterValue"),
           MapEntry.entry("integerSetting", 42));
     }
   }
@@ -57,8 +57,19 @@ public class JsonBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/JsonBasedPropertiesProviderTest_shouldReadNestedValues.json";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("some.setting", "masterValue"),
-          MapEntry.entry("some.integerSetting", 42));
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("some.setting", "masterValue"),
+        MapEntry.entry("some.integerSetting", 42));
+    }
+  }
+
+  @Test
+  public void shouldReadNestedValuesWithSeparator() throws Exception {
+    String path = "org/cfg4j/source/propertiesprovider/JsonBasedPropertiesProviderTest_shouldReadNestedValues.json";
+
+    try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
+      PropertiesProvider provider = new JsonBasedPropertiesProvider("/");
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("some/setting", "masterValue"),
+        MapEntry.entry("some/integerSetting", 42));
     }
   }
 
@@ -77,7 +88,7 @@ public class JsonBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/JsonBasedPropertiesProviderTest_shouldReadTextBlock.json";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("content", "I'm just a text block document"));
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("content", "I'm just a text block document"));
     }
   }
 

--- a/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/PropertyBasedPropertiesProviderTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/PropertyBasedPropertiesProviderTest.java
@@ -47,7 +47,7 @@ public class PropertyBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/PropertyBasedPropertiesProviderTest_shouldLoadProperties.properties";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("property", "abc"));
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("property", "abc"));
     }
   }
 

--- a/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/YamlBasedPropertiesProviderTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/YamlBasedPropertiesProviderTest.java
@@ -47,7 +47,7 @@ public class YamlBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/YamlBasedPropertiesProviderTest_shouldReadSingleValues.yaml";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("setting", "masterValue"),
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("setting", "masterValue"),
           MapEntry.entry("integerSetting", 42));
     }
   }
@@ -57,8 +57,19 @@ public class YamlBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/YamlBasedPropertiesProviderTest_shouldReadNestedValues.yaml";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("some.setting", "masterValue"),
-          MapEntry.entry("some.integerSetting", 42));
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("some.setting", "masterValue"),
+        MapEntry.entry("some.integerSetting", 42));
+    }
+  }
+
+  @Test
+  public void shouldReadNestedValuesWithSeparator() throws Exception {
+    String path = "org/cfg4j/source/propertiesprovider/YamlBasedPropertiesProviderTest_shouldReadNestedValues.yaml";
+
+    try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
+      PropertiesProvider provider = new YamlBasedPropertiesProvider("/");
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("some/setting", "masterValue"),
+        MapEntry.entry("some/integerSetting", 42));
     }
   }
 
@@ -77,7 +88,7 @@ public class YamlBasedPropertiesProviderTest {
     String path = "org/cfg4j/source/propertiesprovider/YamlBasedPropertiesProviderTest_shouldReadTextBlock.yaml";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
-      assertThat(provider.getProperties(input)).containsExactly(MapEntry.entry("content", "I'm just a text block document"));
+      assertThat(provider.getProperties(input)).containsOnly(MapEntry.entry("content", "I'm just a text block document"));
     }
   }
 

--- a/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSourceBuilder.java
+++ b/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSourceBuilder.java
@@ -58,9 +58,7 @@ public class GitConfigurationSourceBuilder {
     tmpPath = Paths.get(System.getProperty("java.io.tmpdir"));
     tmpRepoPrefix = "cfg4j-git-config-repository";
     configFilesProvider = new DefaultConfigFilesProvider();
-    propertiesProviderSelector = new PropertiesProviderSelector(
-        new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
-    );
+    propertiesProviderSelector = PropertiesProviderSelector.createDefault();
   }
 
   /**


### PR DESCRIPTION
In my app I need to obtain configurations from files and from consul (depends from app's config). Also it is very useful to store keys in consul in format `keyPart1/keyPart2/...` Then json- and yaml- parsers must keep the keys with separators different from `"."`
