### PR TITLE
#187 Add possibility to ignore missing file and classpath resources

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
@@ -49,6 +49,8 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
 
   private final ConfigFilesProvider configFilesProvider;
   private final PropertiesProviderSelector propertiesProviderSelector;
+  
+  private boolean ignoreNonExistingFiles = false;
 
   /**
    * Construct {@link ConfigurationSource} backed by classpath files. Uses "application.properties" file
@@ -65,7 +67,7 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
       }
     });
   }
-
+  
   /**
    * Construct {@link ConfigurationSource} backed by classpath files. File paths should by provided by
    * {@link ConfigFilesProvider} and will be treated as relative paths to the environment provided in
@@ -120,6 +122,9 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
     for (Path path : paths) {
       try (InputStream input = getClass().getClassLoader().getResourceAsStream(path.toString())) {
 
+        if (input == null && ignoreNonExistingFiles) {
+          continue;
+        }    	  
         if (input == null) {
           throw new IllegalStateException("Unable to load properties from classpath: " + path);
         }
@@ -135,6 +140,23 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
     return properties;
   }
 
+  /**
+   * Sets whether missing files provided by the {@link ConfigFilesProvider} get ignored.
+   * Set to false by default.
+   * 
+   * @param ignoreNonExistingFiles pass true to ignore
+   */
+  public void setIgnoreNonExistingFiles(boolean ignoreNonExistingFiles) {
+    this.ignoreNonExistingFiles = ignoreNonExistingFiles;
+  }
+  
+  /**
+   * @return true if non-existing files are ignored. By default false is returned.
+   */
+  public boolean getIgnoreNonExistingFiles(){
+    return ignoreNonExistingFiles;
+  }
+  
   @Override
   public void init() {
     // NOP

--- a/cfg4j-core/src/main/java/org/cfg4j/source/files/FilesConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/files/FilesConfigurationSource.java
@@ -27,6 +27,7 @@ import org.cfg4j.source.context.propertiesprovider.PropertiesProviderSelector;
 import org.cfg4j.source.context.propertiesprovider.PropertyBasedPropertiesProvider;
 import org.cfg4j.source.context.propertiesprovider.YamlBasedPropertiesProvider;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,6 +45,7 @@ public class FilesConfigurationSource implements ConfigurationSource {
 
   private final ConfigFilesProvider configFilesProvider;
   private final PropertiesProviderSelector propertiesProviderSelector;
+  private boolean ignoreNonExistingFiles;
 
   /**
    * Construct {@link ConfigurationSource} backed by files. Uses "application.properties" file
@@ -121,7 +123,11 @@ public class FilesConfigurationSource implements ConfigurationSource {
     }
 
     for (Path path : paths) {
-      try (InputStream input = new FileInputStream(path.toFile())) {
+      File file = path.toFile();
+      if (!file.exists() && ignoreNonExistingFiles){
+        continue;
+      }
+      try (InputStream input = new FileInputStream(file)) {
 
         PropertiesProvider provider = propertiesProviderSelector.getProvider(path.getFileName().toString());
         properties.putAll(provider.getProperties(input));
@@ -132,6 +138,23 @@ public class FilesConfigurationSource implements ConfigurationSource {
     }
 
     return properties;
+  }
+  
+  /**
+   * Sets whether missing files provided by the {@link ConfigFilesProvider} get ignored.
+   * Set to false by default.
+   * 
+   * @param ignoreNonExistingFiles pass true to ignore
+   */
+  public void setIgnoreNonExistingFiles(boolean ignoreNonExistingFiles) {
+    this.ignoreNonExistingFiles = ignoreNonExistingFiles;
+  }
+  
+  /**
+   * @return true if non-existing files are ignored. By default false is returned.
+   */
+  public boolean getIgnoreNonExistingFiles(){
+    return ignoreNonExistingFiles;
   }
 
   @Override

--- a/cfg4j-core/src/test/java/org/cfg4j/source/classpath/ClasspathConfigurationSourceTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/classpath/ClasspathConfigurationSourceTest.java
@@ -17,6 +17,12 @@ package org.cfg4j.source.classpath;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+
 import org.assertj.core.data.MapEntry;
 import org.cfg4j.source.context.environment.DefaultEnvironment;
 import org.cfg4j.source.context.environment.Environment;
@@ -30,11 +36,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -131,4 +132,22 @@ public class ClasspathConfigurationSourceTest {
     source.getConfiguration(new DefaultEnvironment());
   }
 
+  @Test
+  public void getConfigurationInoreMissingFiles(){
+    configFilesProvider = new ConfigFilesProvider() {
+      @Override
+      public Iterable<Path> getConfigFiles() {
+        return Collections.singletonList(
+            Paths.get("malformed.properties")
+        );
+      }
+    };
+
+    source = new ClasspathConfigurationSource(configFilesProvider);
+    source.setIgnoreNonExistingFiles(true);
+
+    expectedException.expect(IllegalStateException.class);
+    Properties properties = source.getConfiguration(new DefaultEnvironment());
+    assertThat(properties).isEmpty();
+  }
 }

--- a/cfg4j-core/src/test/java/org/cfg4j/source/files/FilesConfigurationSourceTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/files/FilesConfigurationSourceTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Properties;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -130,6 +131,25 @@ public class FilesConfigurationSourceTest {
 
     expectedException.expect(IllegalStateException.class);
     source.getConfiguration(environment);
+  }
+  
+  @Test
+  public void getConfigurationInoreMissingFiles(){
+    configFilesProvider = new ConfigFilesProvider() {
+      @Override
+      public Iterable<Path> getConfigFiles() {
+        return Collections.singletonList(
+            Paths.get("malformed.properties")
+        );
+      }
+    };
+
+    source = new FilesConfigurationSource(configFilesProvider);
+    source.setIgnoreNonExistingFiles(true);
+
+    expectedException.expect(IllegalStateException.class);
+    Properties properties = source.getConfiguration(environment);
+    assertThat(properties).isEmpty();
   }
 
 }


### PR DESCRIPTION
added a boolean to decide whether paths provided by the ConfigFilesProvider get ignored or lead to an exception.