### PR TITLE
#192 Support default value annotations for configuration beans

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/source/annotation/AnnotationConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/annotation/AnnotationConfigurationSource.java
@@ -1,0 +1,112 @@
+package org.cfg4j.source.annotation;
+
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import org.cfg4j.source.ConfigurationSource;
+import org.cfg4j.source.context.environment.Environment;
+
+/**
+ * Extracts configuration values from annotated configuration classes.
+ * 
+ * <pre>
+ * <code>
+ *  public interface MyConfig {
+ *   
+ *    &#64;DefaultValue("true")
+ *    public boolean enabled();
+ *   
+ *    &#64;DefaultNull
+ *    public String name()
+ *  }
+ * </code>
+ * </pre>
+ */
+public class AnnotationConfigurationSource implements ConfigurationSource {
+
+  private final String prefix;
+
+  private Class<?> configClass;
+
+  private Properties properties;
+
+  /**
+   * @param configClass
+   * @param prefix
+   */
+  public AnnotationConfigurationSource(Class<?> configClass, String prefix) {
+    this.prefix = prefix;
+    this.configClass = configClass;
+  }
+
+  @Override
+  public void init() {
+    properties = new Properties();
+    addDefaults(prefix, configClass);
+  }
+
+  private void addDefaults(String keyPrefix, Class<?> currentClass) {
+    for (Method method : currentClass.getMethods()) {
+      String key = concat(keyPrefix, method.getName());
+      if (isConfigEntry(method)) {
+        addEntryDefault(key, method);
+      } else if (isNestedConfig(method)) {
+        addDefaults(key, method.getReturnType());
+        addNestedDefaults(key, method);
+      }
+    }
+  }
+
+  protected boolean isNestedConfig(Method method) {
+    return false;
+  }
+
+  protected boolean isConfigEntry(Method method) {
+    return method.getDeclaringClass() != Object.class;
+  }
+
+  private void addNestedDefaults(String key, Method method) {
+    DefaultValue[] values = method.getAnnotationsByType(DefaultValue.class);
+    for (DefaultValue value : values) {
+      if (value.key().isEmpty()) {
+        throw new IllegalStateException("defaultValues must specify a key for " + key);
+      }
+      properties.put(concat(key, value.key()), value.value());
+    }
+
+    DefaultNull[] nulls = method.getAnnotationsByType(DefaultNull.class);
+    for (DefaultNull value : nulls) {
+      if (value.key().isEmpty()) {
+        throw new IllegalStateException("defaultNulls must specify a key for " + key);
+      }
+      properties.put(concat(key, value.key()), null);
+    }
+  }
+
+  private static String concat(String prefix, String name) {
+    return prefix + (prefix.isEmpty() ? "" : ".") + name;
+  }
+
+  private void addEntryDefault(String key, Method method) {
+    DefaultNull defaultNull = method.getAnnotation(DefaultNull.class);
+    DefaultValue defaultValue = method.getAnnotation(DefaultValue.class);
+    if (defaultNull != null && defaultValue != null) {
+      throw new IllegalStateException("cannot have both @DefaultValue and @DefaultNull for " + key);
+    }
+    if (defaultValue != null) {
+      if (!defaultValue.key().isEmpty()) {
+        throw new IllegalStateException("defaultValue cannot specify a key for " + key);
+      }
+      properties.put(key, defaultValue.value());
+    }
+    if (defaultNull != null) {
+      properties.put(key, "");
+    }
+  }
+
+  @Override
+  public Properties getConfiguration(Environment environment) {
+    return properties;
+  }
+
+}

--- a/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultNull.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultNull.java
@@ -1,0 +1,10 @@
+package org.cfg4j.source.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface DefaultNull {
+
+	String key() default "";
+}

--- a/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultNulls.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultNulls.java
@@ -1,0 +1,10 @@
+package org.cfg4j.source.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DefaultNulls {
+
+	DefaultNull[] value();
+}

--- a/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultValue.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultValue.java
@@ -1,0 +1,15 @@
+package org.cfg4j.source.annotation;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(DefaultValues.class)
+public @interface DefaultValue {
+
+	String value();
+
+	String key() default "";
+
+}

--- a/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultValues.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/annotation/DefaultValues.java
@@ -1,0 +1,10 @@
+package org.cfg4j.source.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DefaultValues {
+
+	DefaultValue[] value();
+}

--- a/cfg4j-core/src/test/java/org/cfg4j/source/annotation/AnnotatedTestConfig.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/annotation/AnnotatedTestConfig.java
@@ -1,0 +1,17 @@
+package org.cfg4j.source.annotation;
+
+public interface AnnotatedTestConfig {
+
+  @DefaultValue("true")
+  public boolean booleanValue();
+
+  @DefaultValue("someValue")
+  public String stringValue();
+
+  @DefaultValue("13")
+  public int intValue();
+
+  @DefaultNull()
+  public String someNullableValue();
+
+}

--- a/cfg4j-core/src/test/java/org/cfg4j/source/annotation/AnnotationConfigurationSourceTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/annotation/AnnotationConfigurationSourceTest.java
@@ -1,0 +1,36 @@
+package org.cfg4j.source.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.cfg4j.source.context.environment.DefaultEnvironment;
+import org.cfg4j.source.context.environment.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AnnotationConfigurationSourceTest {
+
+  private AnnotationConfigurationSource source;
+  private Environment environment = new DefaultEnvironment();
+
+  @Before
+  public void setUp() throws Exception {
+    source = new AnnotationConfigurationSource(AnnotatedTestConfig.class, "somePrefix");
+    source.init();
+  }
+
+  @Test
+  public void getConfigurationFromAnnotations() throws Exception {
+    Properties properties = source.getConfiguration(environment);
+    assertThat(properties.get("somePrefix.booleanValue")).isEqualTo("true");
+    assertThat(properties.get("somePrefix.stringValue")).isEqualTo("someValue");
+    assertThat(properties.get("somePrefix.intValue")).isEqualTo("13");
+    
+    // note that there is no null support by properties, a bit unfortunate
+    assertThat(properties.get("somePrefix.someNullableValue")).isEqualTo(""); 
+  }
+}


### PR DESCRIPTION
Introduced @DefaultNull and @DefaultValue to annotation configuration interfaces with values.

Implemented an AnnotationConfigurationSource that can be hooked into cfg4j instance to make those annotations available as configuration objects.