### PR TITLE
Make ConsulConfigurationSource public

### DIFF
--- a/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSource.java
+++ b/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSource.java
@@ -37,7 +37,7 @@ import java.util.Properties;
  * <p>
  * Read configuration from the Consul K-V store.
  */
-class ConsulConfigurationSource implements ConfigurationSource {
+public class ConsulConfigurationSource implements ConfigurationSource {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConsulConfigurationSource.class);
 


### PR DESCRIPTION
`ConsulConfigurationSource` is package private but it is the return value of the public function, `ConsulConfigurationSourceBuilder::build`. This causes problems when using kotlin b/c kotlin cannot assign any variable to type `ConsulConfigurationSource` since it is package private. Since `ConsulConfigurationSourceBuilder::build` returns an instance of `ConsulConfigurationSource`, we should make `ConsulConfigurationSource` a public class.