### PR TITLE
Cached configuration source with thread safety

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/source/cached/CachedConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/cached/CachedConfigurationSource.java
@@ -1,0 +1,60 @@
+package org.cfg4j.source.cached;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.cfg4j.source.ConfigurationSource;
+import org.cfg4j.source.context.environment.Environment;
+import org.cfg4j.source.reload.Reloadable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CachedConfigurationSource implements ConfigurationSource, Reloadable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachedConfigurationSource.class);
+
+    private final ConfigurationSource delegate;
+    private final AtomicReference<Properties> properties;
+    private final ThreadLocal<Properties> wrapper;
+    private final Environment environment;
+
+    public CachedConfigurationSource(ConfigurationSource delegate, Environment environment) {
+        this.delegate = delegate;
+        this.environment = environment;
+        this.properties = new AtomicReference<>(new Properties()); // never empty, no NPE
+        this.wrapper = new ThreadLocal<>();
+    }
+
+    @Override
+    public void reload() {
+        try {
+            Properties props = new Properties();
+            props.putAll(properties.get());
+            Properties newProps = delegate.getConfiguration(this.environment);
+            props.putAll(newProps);
+            properties.set(props);
+            LOGGER.debug("Reload properties : {}", properties);
+        } catch (Exception e) {
+            LOGGER.error("Error reloading properties from delegate source : keep old properties", e);
+        }
+    }
+
+    @Override
+    public Properties getConfiguration(Environment environment) {
+        // Get always same properties in same thread
+        Properties props = wrapper.get();
+        if (props == null) {
+            props = properties.get();
+            wrapper.set(props);
+        }
+        return props;
+    }
+
+    @Override
+    public void init() {
+        delegate.init();
+        Properties props = delegate.getConfiguration(environment);
+        properties.set(props);
+    }
+
+}

--- a/cfg4j-core/src/test/java/org/cfg4j/source/cached/CachedConfigurationSourceTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/cached/CachedConfigurationSourceTest.java
@@ -1,0 +1,123 @@
+package org.cfg4j.source.cached;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.cfg4j.source.ConfigurationSource;
+import org.cfg4j.source.context.environment.Environment;
+import org.cfg4j.source.context.environment.ImmutableEnvironment;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+public class CachedConfigurationSourceTest {
+
+    private static final String ENVIRONMENT = "environment";
+    private static final String KEY_1 = "ABC";
+    private static final String KEY_1_VALUE_1 = "123";
+    private static final String KEY_1_VALUE_2 = "456";
+    private static final String KEY_2 = "DEF";
+    private static final String KEY_2_VALUE_1 = "789";
+    private static final String KEY_2_VALUE_2 = "321";
+
+    private ConfigurationSource mockSource;
+    private Environment environment;
+    private CachedConfigurationSource cachedSource;
+
+    @Before
+    public void before() throws Exception {
+        mockSource = Mockito.mock(ConfigurationSource.class);
+        environment = new ImmutableEnvironment(ENVIRONMENT);
+        cachedSource = new CachedConfigurationSource(mockSource, environment);
+    }
+
+    @Test
+    public void propertiesAreLoadedAfterInit() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(KEY_1, KEY_1_VALUE_1);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props);
+
+        cachedSource.init();
+
+        Properties properties = cachedSource.getConfiguration(environment);
+        assertThat(properties.get(KEY_1)).isEqualTo(KEY_1_VALUE_1);
+
+        verify(mockSource).getConfiguration(eq(environment));
+    }
+
+    @Test
+    public void doNotAccessToDelegateSource() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(KEY_1, KEY_1_VALUE_1);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props);
+        cachedSource.init();
+
+        reset(mockSource);
+
+        Properties properties = cachedSource.getConfiguration(environment);
+        assertThat(properties.get(KEY_1)).isEqualTo(KEY_1_VALUE_1);
+
+        verify(mockSource, never()).getConfiguration(eq(environment));
+    }
+
+    @Test
+    public void reloadProperties() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(KEY_1, KEY_1_VALUE_1);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props);
+        cachedSource.init();
+        reset(mockSource);
+
+        Properties props2 = new Properties();
+        props2.setProperty(KEY_1, KEY_1_VALUE_2);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props2);
+
+        cachedSource.reload();
+
+        Properties properties = cachedSource.getConfiguration(environment);
+        assertThat(properties.getProperty(KEY_1)).isEqualTo(KEY_1_VALUE_2);
+    }
+
+    @Test
+    public void mergePropertiesWhenReloadProperties() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(KEY_1, KEY_1_VALUE_1);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props);
+        cachedSource.init();
+        reset(mockSource);
+
+        Properties props2 = new Properties();
+        props2.setProperty(KEY_2, KEY_2_VALUE_1);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props2);
+
+        cachedSource.reload();
+
+        Properties properties = cachedSource.getConfiguration(environment);
+        assertThat(properties.getProperty(KEY_1)).isEqualTo(KEY_1_VALUE_1);
+        assertThat(properties.getProperty(KEY_2)).isEqualTo(KEY_2_VALUE_1);
+    }
+
+    @Test
+    public void keepOldPropertiesIfReloadException() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(KEY_1, KEY_1_VALUE_1);
+        when(mockSource.getConfiguration(Matchers.<Environment> anyObject())).thenReturn(props);
+        cachedSource.init();
+        reset(mockSource);
+
+
+        cachedSource.reload();
+
+        Properties properties = cachedSource.getConfiguration(environment);
+        assertThat(properties.getProperty(KEY_1)).isEqualTo(KEY_1_VALUE_1);
+
+    }
+
+}

--- a/cfg4j-core/src/test/java/org/cfg4j/source/cached/ConcurrentCachedConfigurationSourceTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/cached/ConcurrentCachedConfigurationSourceTest.java
@@ -1,0 +1,175 @@
+package org.cfg4j.source.cached;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.cfg4j.provider.ConfigurationProvider;
+import org.cfg4j.provider.ConfigurationProviderBuilder;
+import org.cfg4j.source.context.environment.ImmutableEnvironment;
+import org.cfg4j.source.files.FilesConfigurationSource;
+import org.cfg4j.source.reload.strategy.PeriodicalReloadStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConcurrentCachedConfigurationSourceTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentCachedConfigurationSourceTest.class);
+
+    private static final String[] TEST_CONFIGURATIONS_FILES = { "/threadSafetyTest/application-1.properties",
+                                                                "/threadSafetyTest/application-2.properties",
+                                                                "/threadSafetyTest/application-3.properties",
+                                                                "/threadSafetyTest/application-4.properties",
+                                                                "/threadSafetyTest/application-5.properties",
+                                                                "/threadSafetyTest/application-6.properties" };
+
+    private PropX propX;
+
+    private AtomicInteger errorCounter;
+    private AtomicInteger changeCounter;
+
+    private CountDownLatch startLatch;
+    private CountDownLatch endLatch;
+
+    private Random random;
+
+    private void check() {
+        try {
+            startLatch.await();
+            if (random.nextLong() % 5 == 0L) {
+                new Thread(new Runnable() {
+                    
+                    @Override
+                    public void run() {
+                        setNewConfiguration();
+                        
+                    }
+                }).start();
+            }
+            String error = "";
+            int factor = propX.prop1();
+            int value = propX.prop2();
+            StringBuilder builder = new StringBuilder(Thread.currentThread().getName()).append("\t->\t").append("factor ").append(factor);
+            Thread.sleep(WAIT_TIME); // simulate long operation
+            builder.append("\t2 * ").append(factor).append(" = ").append(value);
+            if (value != 2 * factor) {
+                errorCounter.incrementAndGet();
+                builder.append("<<<");
+                error = "\t ==> ERROR";
+            }
+            Thread.sleep(WAIT_TIME);
+            value = propX.prop3();
+            builder.append("\t3 * ").append(factor).append(" = ").append(value);
+            if (value != 3 * factor) {
+                errorCounter.incrementAndGet();
+                builder.append("<<<");
+                error = "\t ==> ERROR";
+            }
+            Thread.sleep(WAIT_TIME);
+            value = propX.prop4();
+            builder.append("\t4 * ").append(factor).append(" = ").append(value);
+            if (value != 4 * factor) {
+                errorCounter.incrementAndGet();
+                builder.append("<<<");
+                error = "\t ==> ERROR";
+            }
+            Thread.sleep(WAIT_TIME);
+            value = propX.prop5();
+            builder.append("\t5 * ").append(factor).append(" = ").append(value);
+            if (value != 5 * factor) {
+                errorCounter.incrementAndGet();
+                builder.append("<<<");
+                error = "\t ==> ERROR";
+            }
+            if ( !error.isEmpty()) {
+                LOGGER.info(builder.append(error).toString());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error checking", e);
+            errorCounter.incrementAndGet();
+        } finally {
+            endLatch.countDown();
+        }
+    }
+
+    private static final int THREAD_COUNT = 20_000;
+    private static final int WAIT_TIME = 100;
+    private String tmpDir;
+    private Object copyLock = new Object();
+    private ImmutableEnvironment environment;
+    private CachedConfigurationSource cachedSource;
+
+    private Integer currentConfiguration;
+
+    @Before
+    public void before() throws Exception {
+        tmpDir = System.getProperty("java.io.tmpdir");
+
+        random = new Random();
+        errorCounter = new AtomicInteger(0);
+        startLatch = new CountDownLatch(1);
+        endLatch = new CountDownLatch(THREAD_COUNT);
+        changeCounter = new AtomicInteger(0);
+        currentConfiguration = 0;
+
+        setNewConfiguration();
+
+        FilesConfigurationSource defaultConfigurationSource = new FilesConfigurationSource();
+        environment = new ImmutableEnvironment(tmpDir);
+        cachedSource = new CachedConfigurationSource(defaultConfigurationSource, environment);
+    }
+    
+    // We have to get coherent properties with concurrent access
+    @Test
+    public void concurrentTest() throws Exception {
+        ConfigurationProvider provider =
+                                       new ConfigurationProviderBuilder().withConfigurationSource(cachedSource)
+                                                                         .withEnvironment(environment)
+                                                                         .withReloadStrategy(new PeriodicalReloadStrategy(10, TimeUnit.MILLISECONDS))
+                                                                         .build();
+        propX = provider.bind("", PropX.class);
+
+        for (long i = 0; i < THREAD_COUNT; i++ ) {
+            new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    check();
+                }
+            }).start();
+        }
+        startLatch.countDown();
+        endLatch.await();
+        LOGGER.info("Configuration changes : " + changeCounter.get());
+        LOGGER.info("Errors                : " + errorCounter.get());
+        assertThat(errorCounter.get(), is(0));
+    }
+
+    private void setNewConfiguration() {
+        currentConfiguration++ ;
+        String newConfigurationFile = TEST_CONFIGURATIONS_FILES[currentConfiguration % 6];
+        InputStream inputStream = getClass().getResourceAsStream(newConfigurationFile);
+        String configurationFile = tmpDir + "/application.properties";
+        // Avoid to copy file by many threads in same time
+        synchronized (copyLock) {
+            try {
+                Files.copy(inputStream, Paths.get(configurationFile), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        changeCounter.incrementAndGet();
+    }
+
+}

--- a/cfg4j-core/src/test/java/org/cfg4j/source/cached/PropX.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/cached/PropX.java
@@ -1,0 +1,21 @@
+package org.cfg4j.source.cached;
+
+/**
+ * Simple interface to test binding : prop2 = 2 * prop1, prop3 = 3 * prop1 and so on.
+ * 
+ * @author denis
+ *
+ */
+public interface PropX {
+
+    Integer prop1();
+
+    Integer prop2();
+
+    Integer prop3();
+
+    Integer prop4();
+
+    Integer prop5();
+
+}

--- a/cfg4j-core/src/test/resources/threadSafetyTest/application-1.properties
+++ b/cfg4j-core/src/test/resources/threadSafetyTest/application-1.properties
@@ -1,0 +1,5 @@
+prop1=1
+prop2=2
+prop3=3
+prop4=4
+prop5=5

--- a/cfg4j-core/src/test/resources/threadSafetyTest/application-2.properties
+++ b/cfg4j-core/src/test/resources/threadSafetyTest/application-2.properties
@@ -1,0 +1,5 @@
+prop1=2
+prop2=4
+prop3=6
+prop4=8
+prop5=10

--- a/cfg4j-core/src/test/resources/threadSafetyTest/application-3.properties
+++ b/cfg4j-core/src/test/resources/threadSafetyTest/application-3.properties
@@ -1,0 +1,5 @@
+prop1=3
+prop2=6
+prop3=9
+prop4=12
+prop5=15

--- a/cfg4j-core/src/test/resources/threadSafetyTest/application-4.properties
+++ b/cfg4j-core/src/test/resources/threadSafetyTest/application-4.properties
@@ -1,0 +1,5 @@
+prop1=4
+prop2=8
+prop3=12
+prop4=16
+prop5=20

--- a/cfg4j-core/src/test/resources/threadSafetyTest/application-5.properties
+++ b/cfg4j-core/src/test/resources/threadSafetyTest/application-5.properties
@@ -1,0 +1,5 @@
+prop1=5
+prop2=10
+prop3=15
+prop4=20
+prop5=25

--- a/cfg4j-core/src/test/resources/threadSafetyTest/application-6.properties
+++ b/cfg4j-core/src/test/resources/threadSafetyTest/application-6.properties
@@ -1,0 +1,5 @@
+prop1=6
+prop2=12
+prop3=18
+prop4=24
+prop5=30


### PR DESCRIPTION
Hi,
each access to a property read the configuration file, so with many access in many request, the access time can be important. More, in configuration file change while a thread access to a property, next access in same thread can produce incoherence.
It's for this reason we created CachedConfigurationSource, using AtomicReference to contains properties and ensure thread safety.
I hope that will be useful.
Denis