### PR TITLE
Remove initialized=false if a configuration fails to load

### DIFF
--- a/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSource.java
+++ b/cfg4j-consul/src/main/java/org/cfg4j/source/consul/ConsulConfigurationSource.java
@@ -118,7 +118,6 @@ public class ConsulConfigurationSource implements ConfigurationSource {
       LOG.debug("Reloading configuration from Consuls' K-V store");
       valueList = kvClient.getValues("/");
     } catch (Exception e) {
-      initialized = false;
       throw new SourceCommunicationException("Can't get values from k-v store", e);
     }
 

--- a/cfg4j-consul/src/test/java/org/cfg4j/source/consul/ConsulConfigurationSourceIntegrationTest.java
+++ b/cfg4j-consul/src/test/java/org/cfg4j/source/consul/ConsulConfigurationSourceIntegrationTest.java
@@ -148,7 +148,7 @@ public class ConsulConfigurationSourceIntegrationTest {
       // NOP
     }
 
-    expectedException.expect(IllegalStateException.class);
+    expectedException.expect(SourceCommunicationException.class);
     source.getConfiguration(new ImmutableEnvironment(""));
   }
 


### PR DESCRIPTION
In some cases the key value fetch fails, due to consul being down for a few seconds, or the connection failing, in which case this flag is set to false. If it is set to false, the getConfiguration() method keeps on throwing IllegalStateExceptions, bringing our entire application down. 

I think the purpose of the initialized flag was to to prevent getConfiguration() being called before init() completed, and hence setting the flag here is not needed.