### PR TITLE
Add a property annotation to explicitly bind interfaces

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/provider/BindInvocationHandler.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/provider/BindInvocationHandler.java
@@ -58,12 +58,26 @@ class BindInvocationHandler implements InvocationHandler {
     }
 
     final Type returnType = method.getGenericReturnType();
-    return simpleConfigurationProvider.getProperty(prefix + (prefix.isEmpty() ? "" : ".") + method.getName(), new GenericTypeInterface() {
+    final String propertyName = getPropertyName(method);
+    return simpleConfigurationProvider.getProperty(prefix + (prefix.isEmpty() ? "" : ".") + propertyName, new GenericTypeInterface() {
       @Override
       public Type getType() {
         return returnType;
       }
     });
+  }
+
+  /**
+   * Get the property name for the given method, using the {@link Property} annotation if available and the method name
+   * if not
+   */
+  private String getPropertyName(Method method) {
+    Property property = method.getAnnotation(Property.class);
+    if (property == null) {
+      return method.getName();
+    }
+
+    return property.name();
   }
 
   /**

--- a/cfg4j-core/src/main/java/org/cfg4j/provider/Property.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/provider/Property.java
@@ -1,0 +1,18 @@
+package org.cfg4j.provider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker to specify how a method is bound to a property
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Property {
+  /**
+   * The name of the property that should be bound to this method
+   */
+  String name();
+}

--- a/cfg4j-core/src/test/java/org/cfg4j/provider/BindInvocationHandlerTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/provider/BindInvocationHandlerTest.java
@@ -59,6 +59,14 @@ public class BindInvocationHandlerTest {
   }
 
   @Test
+  public void respectsPropertyAnnotation() throws Exception {
+    when(configurationProvider.getProperty(eq("testMethod"), any(GenericTypeInterface.class))).thenReturn("yes");
+    BindInvocationHandler handler = new BindInvocationHandler(configurationProvider, "");
+    String result = (String) handler.invoke(this, this.getClass().getMethod("annotatedMethod"), new Object[]{});
+    assertThat(result).isEqualTo("yes");
+  }
+
+  @Test
   public void usesDefaultNamespaceWhenNoPrefix() throws Exception {
     BindInvocationHandler handler = new BindInvocationHandler(configurationProvider, "");
 
@@ -131,6 +139,11 @@ public class BindInvocationHandlerTest {
 
   // For "mocking" java.lang.reflect.Method
   public String stringMethod() {
+    return null;
+  }
+
+  @Property(name = "testMethod")
+  public String annotatedMethod() {
     return null;
   }
 


### PR DESCRIPTION
Hi!

This change adds a property annotation which would allow you to override the name of a property if needed (e.g. if a property name can't be expressed as a method name) and would make it easier to see that the values are being bound by cfg4j.

At my company we include explicit serialization annotations when available, so I wanted to be able to support that in cfg4j, which I'm interested in using to replace an internal system we have.

A property annotation might also be a convenient way to allow for default values in the future:

```
public interface DatabaseProperties {
    String jdbcUrl();
    @Property(default = "com.mysql.cj.jdbc.Driver")
    String driver();
    // ...
}
```

Please let me know if there are any issues with this submission or if I should include more tests.

Thank you for your time!