### PR TITLE
Support for hocon format

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/classpath/ClasspathConfigurationSource.java
@@ -21,11 +21,8 @@ import org.cfg4j.source.ConfigurationSource;
 import org.cfg4j.source.context.environment.Environment;
 import org.cfg4j.source.context.environment.MissingEnvironmentException;
 import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
-import org.cfg4j.source.context.propertiesprovider.JsonBasedPropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.PropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.PropertiesProviderSelector;
-import org.cfg4j.source.context.propertiesprovider.PropertyBasedPropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.YamlBasedPropertiesProvider;
+import org.cfg4j.source.context.propertiesprovider.*;
+import org.cfg4j.source.context.propertiesprovider.DefaultPropertiesProviderSelector;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,12 +67,12 @@ public class ClasspathConfigurationSource implements ConfigurationSource {
    * Construct {@link ConfigurationSource} backed by classpath files. File paths should by provided by
    * {@link ConfigFilesProvider} and will be treated as relative paths to the environment provided in
    * {@link #getConfiguration(Environment)} calls (see corresponding javadoc for detail). Configuration
-   * file type is detected using file extension (see {@link PropertiesProviderSelector}).
+   * file type is detected using file extension (see {@link DefaultPropertiesProviderSelector}).
    *
    * @param configFilesProvider {@link ConfigFilesProvider} supplying a list of configuration files to use
    */
   public ClasspathConfigurationSource(ConfigFilesProvider configFilesProvider) {
-    this(configFilesProvider, new PropertiesProviderSelector(
+    this(configFilesProvider, new DefaultPropertiesProviderSelector(
         new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
     ));
   }

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/DefaultPropertiesProviderSelector.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/DefaultPropertiesProviderSelector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2016 Norbert Potocki (norbert.potocki@nort.pl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cfg4j.source.context.propertiesprovider;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Selects {@link PropertiesProvider} to use based on a file extension.
+ */
+public class DefaultPropertiesProviderSelector implements PropertiesProviderSelector {
+
+  private final PropertiesProvider yamlProvider;
+  private final PropertiesProvider jsonProvider;
+  private final PropertiesProvider propertiesProvider;
+
+  /**
+   * Construct selector.
+   *
+   * @param propertiesProvider provider used for parsing properties files
+   * @param yamlProvider       provider used for parsing Yaml files
+   * @param jsonProvider       provider used for parsing JSON files
+   */
+  public DefaultPropertiesProviderSelector(PropertiesProvider propertiesProvider, PropertiesProvider yamlProvider, PropertiesProvider jsonProvider) {
+    this.propertiesProvider = requireNonNull(propertiesProvider);
+    this.yamlProvider = requireNonNull(yamlProvider);
+    this.jsonProvider = requireNonNull(jsonProvider);
+  }
+
+  /**
+   * Selects {@link PropertiesProvider} to use based on a file extension. For *.yaml files
+   * returns {@code yamlProvider}. For any other extension returns {@code propertiesProvider}.
+   *
+   * @param filename configuration file name
+   * @return provider for the give file type
+   */
+  public PropertiesProvider getProvider(String filename) {
+    if (filename.endsWith(".yaml") || filename.endsWith(".yml")) {
+      return yamlProvider;
+    } else if (filename.endsWith(".json")) {
+      return jsonProvider;
+    } else {
+      return propertiesProvider;
+    }
+  }
+}

--- a/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/PropertiesProviderSelector.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/context/propertiesprovider/PropertiesProviderSelector.java
@@ -1,3 +1,5 @@
+package org.cfg4j.source.context.propertiesprovider;
+
 /*
  * Copyright 2015-2016 Norbert Potocki (norbert.potocki@nort.pl)
  *
@@ -14,46 +16,6 @@
  * limitations under the License.
  */
 
-package org.cfg4j.source.context.propertiesprovider;
-
-import static java.util.Objects.requireNonNull;
-
-/**
- * Selects {@link PropertiesProvider} to use based on a file extension.
- */
-public class PropertiesProviderSelector {
-
-  private final PropertiesProvider yamlProvider;
-  private final PropertiesProvider jsonProvider;
-  private final PropertiesProvider propertiesProvider;
-
-  /**
-   * Construct selector.
-   *
-   * @param propertiesProvider provider used for parsing properties files
-   * @param yamlProvider       provider used for parsing Yaml files
-   * @param jsonProvider       provider used for parsing JSON files
-   */
-  public PropertiesProviderSelector(PropertiesProvider propertiesProvider, PropertiesProvider yamlProvider, PropertiesProvider jsonProvider) {
-    this.propertiesProvider = requireNonNull(propertiesProvider);
-    this.yamlProvider = requireNonNull(yamlProvider);
-    this.jsonProvider = requireNonNull(jsonProvider);
-  }
-
-  /**
-   * Selects {@link PropertiesProvider} to use based on a file extension. For *.yaml files
-   * returns {@code yamlProvider}. For any other extension returns {@code propertiesProvider}.
-   *
-   * @param filename configuration file name
-   * @return provider for the give file type
-   */
-  public PropertiesProvider getProvider(String filename) {
-    if (filename.endsWith(".yaml") || filename.endsWith(".yml")) {
-      return yamlProvider;
-    } else if (filename.endsWith(".json")) {
-      return jsonProvider;
-    } else {
-      return propertiesProvider;
-    }
-  }
+public interface PropertiesProviderSelector {
+  PropertiesProvider getProvider(String filename);
 }

--- a/cfg4j-core/src/main/java/org/cfg4j/source/files/FilesConfigurationSource.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/source/files/FilesConfigurationSource.java
@@ -21,11 +21,8 @@ import org.cfg4j.source.ConfigurationSource;
 import org.cfg4j.source.context.environment.Environment;
 import org.cfg4j.source.context.environment.MissingEnvironmentException;
 import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
-import org.cfg4j.source.context.propertiesprovider.JsonBasedPropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.PropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.PropertiesProviderSelector;
-import org.cfg4j.source.context.propertiesprovider.PropertyBasedPropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.YamlBasedPropertiesProvider;
+import org.cfg4j.source.context.propertiesprovider.*;
+import org.cfg4j.source.context.propertiesprovider.DefaultPropertiesProviderSelector;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -65,12 +62,12 @@ public class FilesConfigurationSource implements ConfigurationSource {
    * Construct {@link ConfigurationSource} backed by files. File paths should by provided by
    * {@link ConfigFilesProvider} and will be treated as relative paths to the environment provided in
    * {@link #getConfiguration(Environment)} calls (see corresponding javadoc for detail). Configuration
-   * file type is detected using file extension (see {@link PropertiesProviderSelector}).
+   * file type is detected using file extension (see {@link DefaultPropertiesProviderSelector}).
    *
    * @param configFilesProvider {@link ConfigFilesProvider} supplying a list of configuration files to use
    */
   public FilesConfigurationSource(ConfigFilesProvider configFilesProvider) {
-    this(configFilesProvider, new PropertiesProviderSelector(
+    this(configFilesProvider, new DefaultPropertiesProviderSelector(
         new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
     ));
   }
@@ -79,7 +76,7 @@ public class FilesConfigurationSource implements ConfigurationSource {
    * Construct {@link ConfigurationSource} backed by files. File paths should by provided by
    * {@link ConfigFilesProvider} and will be treated as relative paths to the environment provided in
    * {@link #getConfiguration(Environment)} calls (see corresponding javadoc for detail). Configuration
-   * file type is detected using file extension (see {@link PropertiesProviderSelector}).
+   * file type is detected using file extension (see {@link DefaultPropertiesProviderSelector}).
    *
    * @param configFilesProvider        {@link ConfigFilesProvider} supplying a list of configuration files to use
    * @param propertiesProviderSelector selector used for choosing {@link PropertiesProvider} based on a configuration file extension

--- a/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/PropertiesProviderSelectorTest.java
+++ b/cfg4j-core/src/test/java/org/cfg4j/source/context/propertiesprovider/PropertiesProviderSelectorTest.java
@@ -63,7 +63,7 @@ public class PropertiesProviderSelectorTest {
     propertiesProperties = new Properties();
     when(yamlProvider.getProperties(any(InputStream.class))).thenReturn(propertiesProperties);
 
-    selector = new PropertiesProviderSelector(propertiesProvider, yamlProvider, jsonProvider);
+    selector = new DefaultPropertiesProviderSelector(propertiesProvider, yamlProvider, jsonProvider);
   }
 
   @Test

--- a/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSource.java
+++ b/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSource.java
@@ -22,6 +22,7 @@ import org.cfg4j.source.SourceCommunicationException;
 import org.cfg4j.source.context.environment.Environment;
 import org.cfg4j.source.context.environment.MissingEnvironmentException;
 import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
+import org.cfg4j.source.context.propertiesprovider.DefaultPropertiesProviderSelector;
 import org.cfg4j.source.context.propertiesprovider.PropertiesProvider;
 import org.cfg4j.source.context.propertiesprovider.PropertiesProviderSelector;
 import org.cfg4j.utils.FileUtils;

--- a/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSourceBuilder.java
+++ b/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSourceBuilder.java
@@ -130,7 +130,7 @@ public class GitConfigurationSourceBuilder {
   }
 
   /**
-   * Set {@link ConfigFilesProvider} for {@link GitConfigurationSource}s built by this builder
+   * Set {@link PropertiesProviderSelector} for {@link GitConfigurationSource}s built by this builder
    *
    * @param propertiesProviderSelector {@link PropertiesProviderSelector} to use
    * @return this builder with {@link PropertiesProviderSelector} set to {@code propertiesProviderSelector}

--- a/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSourceBuilder.java
+++ b/cfg4j-git/src/main/java/org/cfg4j/source/git/GitConfigurationSourceBuilder.java
@@ -17,10 +17,7 @@ package org.cfg4j.source.git;
 
 import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
 import org.cfg4j.source.context.filesprovider.DefaultConfigFilesProvider;
-import org.cfg4j.source.context.propertiesprovider.JsonBasedPropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.PropertiesProviderSelector;
-import org.cfg4j.source.context.propertiesprovider.PropertyBasedPropertiesProvider;
-import org.cfg4j.source.context.propertiesprovider.YamlBasedPropertiesProvider;
+import org.cfg4j.source.context.propertiesprovider.*;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,7 +45,7 @@ public class GitConfigurationSourceBuilder {
    * <li>ConfigFilesProvider: {@link DefaultConfigFilesProvider}</li>
    * <li>tmpPath: System.getProperty("java.io.tmpdir")</li>
    * <li>tmpRepoPrefix: "cfg4j-config-git-config-repository"</li>
-   * <li>propertiesProviderSelector: {@link PropertiesProviderSelector} with {@link PropertyBasedPropertiesProvider}
+   * <li>propertiesProviderSelector: {@link DefaultPropertiesProviderSelector} with {@link PropertyBasedPropertiesProvider}
    * and {@link YamlBasedPropertiesProvider} providers</li>
    * </ul>
    */
@@ -58,10 +55,13 @@ public class GitConfigurationSourceBuilder {
     tmpPath = Paths.get(System.getProperty("java.io.tmpdir"));
     tmpRepoPrefix = "cfg4j-git-config-repository";
     configFilesProvider = new DefaultConfigFilesProvider();
-    propertiesProviderSelector = new PropertiesProviderSelector(
-        new PropertyBasedPropertiesProvider(), new YamlBasedPropertiesProvider(), new JsonBasedPropertiesProvider()
+    propertiesProviderSelector = new DefaultPropertiesProviderSelector(
+      new PropertyBasedPropertiesProvider(),
+      new YamlBasedPropertiesProvider(),
+      new JsonBasedPropertiesProvider()
     );
   }
+
 
   /**
    * Set {@link BranchResolver} for {@link GitConfigurationSource}s built by this builder
@@ -130,24 +130,35 @@ public class GitConfigurationSourceBuilder {
   }
 
   /**
+   * Set {@link ConfigFilesProvider} for {@link GitConfigurationSource}s built by this builder
+   *
+   * @param propertiesProviderSelector {@link PropertiesProviderSelector} to use
+   * @return this builder with {@link PropertiesProviderSelector} set to {@code propertiesProviderSelector}
+   */
+  public GitConfigurationSourceBuilder withPropertiesProviderSelector(PropertiesProviderSelector propertiesProviderSelector) {
+    this.propertiesProviderSelector = propertiesProviderSelector;
+    return this;
+  }
+
+  /**
    * Build a {@link GitConfigurationSource} using this builder's configuration
    *
    * @return new {@link GitConfigurationSource}
    */
   public GitConfigurationSource build() {
     return new GitConfigurationSource(repositoryURI, tmpPath, tmpRepoPrefix, branchResolver, pathResolver,
-        configFilesProvider, propertiesProviderSelector);
+      configFilesProvider, propertiesProviderSelector);
   }
 
   @Override
   public String toString() {
     return "GitConfigurationSourceBuilder{" +
-        "branchResolver=" + branchResolver +
-        ", pathResolver=" + pathResolver +
-        ", repositoryURI='" + repositoryURI + '\'' +
-        ", tmpPath='" + tmpPath + '\'' +
-        ", tmpRepoPrefix='" + tmpRepoPrefix + '\'' +
-        ", configFilesProvider=" + configFilesProvider +
-        '}';
+      "branchResolver=" + branchResolver +
+      ", pathResolver=" + pathResolver +
+      ", repositoryURI='" + repositoryURI + '\'' +
+      ", tmpPath='" + tmpPath + '\'' +
+      ", tmpRepoPrefix='" + tmpRepoPrefix + '\'' +
+      ", configFilesProvider=" + configFilesProvider +
+      '}';
   }
 }

--- a/cfg4j-support-hocon/build.gradle
+++ b/cfg4j-support-hocon/build.gradle
@@ -13,4 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-include 'cfg4j-core', 'cfg4j-git', 'cfg4j-consul', 'cfg4j-s3', 'cfg4j-support-hocon'
+// ----------- Build script configuration -----------
+
+buildscript {
+
+    ext {
+        artifactName = "cfg4j-support-hocon"
+    }
+}
+
+// ----------- External module dependencies -----------
+
+dependencies {
+
+    compile project(":cfg4j-core")
+
+    compile group: 'com.typesafe', name: 'config', version: '1.0.2'
+}
+
+// ----------- Task configurations -----------
+jar {
+    baseName = "${artifactName}"
+    version = "${artifactVersion}"
+}
+
+archivesBaseName = "${artifactName}"

--- a/cfg4j-support-hocon/src/main/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconBasedPropertiesProvider.java
+++ b/cfg4j-support-hocon/src/main/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconBasedPropertiesProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2016 Norbert Potocki (norbert.potocki@nort.pl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cfg4j.source.context.propertiesprovider.hocon;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigRenderOptions;
+import org.cfg4j.source.context.propertiesprovider.JsonBasedPropertiesProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+public class HoconBasedPropertiesProvider extends JsonBasedPropertiesProvider {
+  @Override
+  public Properties getProperties(InputStream inputStream) {
+
+    InputStreamReader reader = new InputStreamReader(inputStream);
+
+    Config config = ConfigFactory.parseReader(reader);
+
+    //Render to JSON (no whitespace or comments)
+    String conciseRendered = config.root().render(ConfigRenderOptions.concise());
+
+    byte[] bytes = conciseRendered.getBytes(StandardCharsets.UTF_8);
+
+    InputStream modified = new ByteArrayInputStream(bytes);
+
+    return super.getProperties(modified);
+  }
+}

--- a/cfg4j-support-hocon/src/main/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconConfigFilesProvider.java
+++ b/cfg4j-support-hocon/src/main/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconConfigFilesProvider.java
@@ -1,0 +1,25 @@
+package org.cfg4j.source.context.propertiesprovider.hocon;
+
+import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+
+/**
+ * Provides default configuration file (i.e. application.properties).
+ */
+public class HoconConfigFilesProvider implements ConfigFilesProvider {
+
+  @Override
+  public Iterable<Path> getConfigFiles() {
+
+    return Collections.singletonList(Paths.get("application.conf"));
+  }
+
+  @Override
+  public String toString() {
+    return "HoconConfigFilesProvider{}";
+  }
+}

--- a/cfg4j-support-hocon/src/main/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconPropertiesProviderSelector.java
+++ b/cfg4j-support-hocon/src/main/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconPropertiesProviderSelector.java
@@ -1,0 +1,57 @@
+package org.cfg4j.source.context.propertiesprovider.hocon;
+
+import org.cfg4j.source.context.propertiesprovider.*;
+
+
+public class HoconPropertiesProviderSelector extends DefaultPropertiesProviderSelector {
+
+  private final PropertiesProvider hoconProvider;
+
+  /**
+   * Construct selector.
+   *
+   * @param propertiesProvider provider used for parsing properties files
+   * @param yamlProvider       provider used for parsing Yaml files
+   * @param jsonProvider       provider used for parsing JSON files
+   * @param hoconProvider      provider used for parsing HOCON files
+   */
+  public HoconPropertiesProviderSelector(PropertiesProvider propertiesProvider,
+                                         PropertiesProvider yamlProvider,
+                                         PropertiesProvider jsonProvider,
+                                         PropertiesProvider hoconProvider) {
+    super(
+      propertiesProvider,
+      yamlProvider,
+      jsonProvider
+    );
+    this.hoconProvider = hoconProvider;
+  }
+
+  /**
+   * Construct selector.
+   */
+  public HoconPropertiesProviderSelector() {
+    this(
+      new PropertyBasedPropertiesProvider(),
+      new YamlBasedPropertiesProvider(),
+      new JsonBasedPropertiesProvider(),
+      new HoconBasedPropertiesProvider()
+    );
+  }
+
+  /**
+   * Selects {@link PropertiesProvider} to use based on a file extension. For *.yaml files
+   * returns {@code yamlProvider}. For any other extension returns {@code propertiesProvider}.
+   *
+   * @param filename configuration file name
+   * @return provider for the give file type
+   */
+  @Override
+  public PropertiesProvider getProvider(String filename) {
+    if (filename.endsWith(".conf")) {
+      return hoconProvider;
+    } else {
+      return super.getProvider(filename);
+    }
+  }
+}

--- a/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconBasedPropertiesProviderTest.java
+++ b/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconBasedPropertiesProviderTest.java
@@ -50,8 +50,8 @@ public class HoconBasedPropertiesProviderTest {
 
       Properties properties = provider.getProperties(input);
 
-      String actual = properties.get("zepto.queue.size").toString();
-      String expected = "666";
+      String actual = properties.get("hoconf.queue.size").toString();
+      String expected = "1000";
 
       Assert.assertTrue(Objects.equals(actual, expected));
     }

--- a/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconBasedPropertiesProviderTest.java
+++ b/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconBasedPropertiesProviderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2016 Norbert Potocki (norbert.potocki@nort.pl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cfg4j.source.context.propertiesprovider.hocon;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HoconBasedPropertiesProviderTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private HoconBasedPropertiesProvider provider;
+
+  @Before
+  public void Before() {
+    provider = new HoconBasedPropertiesProvider();
+  }
+
+  @Test
+  public void hoconToProperties() throws Exception {
+
+    String path = "test-hocon.conf";
+
+    try (InputStream input = getClass().getClassLoader().getResourceAsStream(path)) {
+
+      Properties properties = provider.getProperties(input);
+
+      String actual = properties.get("zepto.queue.size").toString();
+      String expected = "666";
+
+      Assert.assertTrue(Objects.equals(actual, expected));
+    }
+  }
+}

--- a/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconConfigFilesProviderTest.java
+++ b/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconConfigFilesProviderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Norbert Potocki (norbert.potocki@nort.pl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cfg4j.source.context.propertiesprovider.hocon;
+
+import org.cfg4j.source.context.filesprovider.ConfigFilesProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HoconConfigFilesProviderTest {
+
+  @Test
+  public void providesDefaultConfigFile() throws Exception {
+    ConfigFilesProvider provider = new HoconConfigFilesProvider();
+    assertThat(provider.getConfigFiles()).containsExactly(Paths.get("application.conf"));
+  }
+}

--- a/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconPropertiesProviderSelectorTest.java
+++ b/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconPropertiesProviderSelectorTest.java
@@ -61,8 +61,11 @@ public class HoconPropertiesProviderSelectorTest {
     hoconProperties = new Properties();
     when(hoconProvider.getProperties(any(InputStream.class))).thenReturn(hoconProperties);
 
-    selector = new HoconPropertiesProviderSelector(propertiesProvider,
-      yamlProvider, jsonProvider, hoconProvider);
+    selector = new HoconPropertiesProviderSelector(
+      propertiesProvider,
+      yamlProvider,
+      jsonProvider,
+      hoconProvider);
   }
 
   @Test

--- a/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconPropertiesProviderSelectorTest.java
+++ b/cfg4j-support-hocon/src/test/java/org/cfg4j/source/context/propertiesprovider/hocon/HoconPropertiesProviderSelectorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2016 Norbert Potocki (norbert.potocki@nort.pl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cfg4j.source.context.propertiesprovider.hocon;
+
+import org.cfg4j.source.context.propertiesprovider.DefaultPropertiesProviderSelector;
+import org.cfg4j.source.context.propertiesprovider.PropertiesProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HoconPropertiesProviderSelectorTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private PropertiesProvider propertiesProvider;
+
+  @Mock
+  private PropertiesProvider yamlProvider;
+
+  @Mock
+  private PropertiesProvider jsonProvider;
+
+  @Mock
+  private PropertiesProvider hoconProvider;
+  private Properties hoconProperties;
+
+
+  private DefaultPropertiesProviderSelector selector;
+
+  @Before
+  public void setUp() throws Exception {
+    hoconProperties = new Properties();
+    when(hoconProvider.getProperties(any(InputStream.class))).thenReturn(hoconProperties);
+
+    selector = new HoconPropertiesProviderSelector(propertiesProvider,
+      yamlProvider, jsonProvider, hoconProvider);
+  }
+
+  @Test
+  public void returnsHOCONProviderForConf() throws Exception {
+    assertThat(selector.getProvider("test.conf")).isEqualTo(hoconProvider);
+  }
+
+}

--- a/cfg4j-support-hocon/src/test/resources/test-hocon.conf
+++ b/cfg4j-support-hocon/src/test/resources/test-hocon.conf
@@ -5,15 +5,15 @@ log {
   level = INFO #log
 }
 
-zepto {
-  name = zepto # comment
-  type = zepto.RestioResource
+hoconf {
+  name = hoconconf # comment
+  type = hoconconf.RestioResource
   enabled = true
-  uri = "https://zepto.nomans-sky.net:443"
+  uri = "https://hoconconf.nomans-sky.net:443"
   scope = "uid"
   queue {
     batch-size = 33 //comment
-    size = 666
+    size = 1000
   }
   circuit-breaker {
     max-failures = 15

--- a/cfg4j-support-hocon/src/test/resources/test-hocon.conf
+++ b/cfg4j-support-hocon/src/test/resources/test-hocon.conf
@@ -1,0 +1,23 @@
+# Test HOCON
+
+env.name = local
+log {
+  level = INFO #log
+}
+
+zepto {
+  name = zepto # comment
+  type = zepto.RestioResource
+  enabled = true
+  uri = "https://zepto.nomans-sky.net:443"
+  scope = "uid"
+  queue {
+    batch-size = 33 //comment
+    size = 666
+  }
+  circuit-breaker {
+    max-failures = 15
+    call-timeout = 1000ms
+    reset-timeout = 1 minute
+  }
+}


### PR DESCRIPTION
implements #230 

**Sample HOCON**
```
# Test HOCON
app {
  name = My App  #comment
}
```

**Sample code**
```scala
trait ApplicationConfig {
  def name: String
}

val repository = "https://github.com/username/config-repo.git"
val branch: String = "staging"

val provider = new ConfigurationProviderBuilder()
      .withConfigurationSource(
        new GitConfigurationSourceBuilder()
          .withRepositoryURI(repository)
          .withPropertiesProviderSelector(new HoconPropertiesProviderSelector())
          .withConfigFilesProvider(new HoconConfigFilesProvider)
          .build())
      .withEnvironment(new ImmutableEnvironment(branch))
      .withReloadStrategy(new PeriodicalReloadStrategy(5, TimeUnit.SECONDS))
      .build()

val config = provider.bind("app", classOf[ApplicationConfig])

println(s"App name=${config.name}")
```