### PR TITLE
Switching oraclejdk7 to openjdk7 due to lack of support on trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7


### PR DESCRIPTION
This is addressed in [a github issue on the matter][1], summarised in
that all builds run on trusty that use `oraclejdk7` as their jdk will
categorically fail.

[1]: https://github.com/travis-ci/travis-ci/issues/7019#issuecomment-316769716