### PR TITLE
Adding TypeParser customisation

### DIFF
--- a/cfg4j-core/src/main/java/org/cfg4j/provider/ConfigurationProviderBuilder.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/provider/ConfigurationProviderBuilder.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.github.drapostolos.typeparser.TypeParser;
 import org.cfg4j.source.ConfigurationSource;
 import org.cfg4j.source.context.environment.DefaultEnvironment;
 import org.cfg4j.source.context.environment.Environment;
@@ -46,6 +47,7 @@ public class ConfigurationProviderBuilder {
   private Environment environment;
   private MetricRegistry metricRegistry;
   private String prefix;
+  private TypeParser typeParser;
 
   /**
    * Construct {@link ConfigurationProvider}s builder.
@@ -63,6 +65,7 @@ public class ConfigurationProviderBuilder {
     reloadStrategy = new ImmediateReloadStrategy();
     environment = new DefaultEnvironment();
     prefix = "";
+    typeParser = TypeParser.builder().build();
   }
 
   /**
@@ -125,6 +128,16 @@ public class ConfigurationProviderBuilder {
     this.metricRegistry = metricRegistry;
     return this;
   }
+  
+  /**
+   * Use a custom {@link TypeParser} to read properties into desired objects.
+   *
+   * @return new {@link ConfigurationProvider}
+   */
+  public ConfigurationProviderBuilder withTypeParser(TypeParser typeParser) {
+    this.typeParser = typeParser;
+    return this;
+  }
 
   /**
    * Build a {@link ConfigurationProvider} using this builder's configuration.
@@ -134,8 +147,9 @@ public class ConfigurationProviderBuilder {
   public ConfigurationProvider build() {
     LOG.info("Initializing ConfigurationProvider with "
         + configurationSource.getClass().getCanonicalName() + " source, "
-        + reloadStrategy.getClass().getCanonicalName() + " reload strategy and "
-        + environment.getClass().getCanonicalName() + " environment");
+        + reloadStrategy.getClass().getCanonicalName() + " reload strategy, "
+        + environment.getClass().getCanonicalName() + " environment and "
+        + typeParser.getClass().getCanonicalName() + " type parser");
 
     final CachedConfigurationSource cachedConfigurationSource = new CachedConfigurationSource(configurationSource);
     if (metricRegistry != null) {
@@ -156,7 +170,7 @@ public class ConfigurationProviderBuilder {
     reloadable.reload();
     reloadStrategy.register(reloadable);
 
-    SimpleConfigurationProvider configurationProvider = new SimpleConfigurationProvider(cachedConfigurationSource, environment);
+    SimpleConfigurationProvider configurationProvider = new SimpleConfigurationProvider(cachedConfigurationSource, environment, typeParser);
     if (metricRegistry != null) {
       return new MeteredConfigurationProvider(metricRegistry, prefix, configurationProvider);
     }
@@ -172,6 +186,7 @@ public class ConfigurationProviderBuilder {
         ", environment=" + environment +
         ", metricRegistry=" + metricRegistry +
         ", prefix='" + prefix + '\'' +
+        ", typeParser=" + typeParser +
         '}';
   }
 }

--- a/cfg4j-core/src/main/java/org/cfg4j/provider/ConfigurationProviderBuilder.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/provider/ConfigurationProviderBuilder.java
@@ -65,7 +65,7 @@ public class ConfigurationProviderBuilder {
     reloadStrategy = new ImmediateReloadStrategy();
     environment = new DefaultEnvironment();
     prefix = "";
-    typeParser = TypeParser.builder().build();
+    typeParser = TypeParser.newBuilder().build();
   }
 
   /**

--- a/cfg4j-core/src/main/java/org/cfg4j/provider/SimpleConfigurationProvider.java
+++ b/cfg4j-core/src/main/java/org/cfg4j/provider/SimpleConfigurationProvider.java
@@ -37,7 +37,23 @@ class SimpleConfigurationProvider implements ConfigurationProvider {
 
   private final ConfigurationSource configurationSource;
   private final Environment environment;
+  private final TypeParser typeParser;
 
+  /**
+   * {@link ConfigurationProvider} backed by provided {@link ConfigurationSource}, using {@code environment}
+   * to select environment, and {@code typeParser} to parse property values. To construct this provider use
+   * {@link ConfigurationProviderBuilder}.
+   *
+   * @param configurationSource source for configuration
+   * @param environment         {@link Environment} to use
+   * @param typeParser          parser for string values
+   */
+  SimpleConfigurationProvider(ConfigurationSource configurationSource, Environment environment, TypeParser typeParser) {
+    this.configurationSource = requireNonNull(configurationSource);
+    this.environment = requireNonNull(environment);
+    this.typeParser = requireNonNull(typeParser);
+  }
+  
   /**
    * {@link ConfigurationProvider} backed by provided {@link ConfigurationSource} and using {@code environment}
    * to select environment. To construct this provider use {@link ConfigurationProviderBuilder}.
@@ -46,8 +62,7 @@ class SimpleConfigurationProvider implements ConfigurationProvider {
    * @param environment         {@link Environment} to use
    */
   SimpleConfigurationProvider(ConfigurationSource configurationSource, Environment environment) {
-    this.configurationSource = requireNonNull(configurationSource);
-    this.environment = requireNonNull(environment);
+    this(configurationSource, environment, TypeParser.newBuilder().build());
   }
 
   @Override
@@ -64,8 +79,7 @@ class SimpleConfigurationProvider implements ConfigurationProvider {
     String propertyStr = getProperty(key);
 
     try {
-      TypeParser parser = TypeParser.newBuilder().build();
-      return parser.parse(propertyStr, type);
+      return typeParser.parse(propertyStr, type);
     } catch (TypeParserException | NoSuchRegisteredParserException e) {
       throw new IllegalArgumentException("Unable to cast value \'" + propertyStr + "\' to " + type, e);
     }
@@ -76,9 +90,8 @@ class SimpleConfigurationProvider implements ConfigurationProvider {
     String propertyStr = getProperty(key);
 
     try {
-      TypeParser parser = TypeParser.newBuilder().build();
       @SuppressWarnings("unchecked")
-      T property = (T) parser.parseType(propertyStr, genericType.getType());
+      T property = (T) typeParser.parseType(propertyStr, genericType.getType());
       return property;
     } catch (TypeParserException | NoSuchRegisteredParserException e) {
       throw new IllegalArgumentException("Unable to cast value \'" + propertyStr + "\' to " + genericType, e);
@@ -135,6 +148,7 @@ class SimpleConfigurationProvider implements ConfigurationProvider {
     return "SimpleConfigurationProvider{" +
         "configurationSource=" + configurationSource +
         ", environment=" + environment +
+        ", typeParser=" + typeParser +
         '}';
   }
 }


### PR DESCRIPTION
I haven't tested the changes yet, and I'm sure that tests need updating, but I found that the `TypeParser` used in `SimpleConfigurationProvider` couldn't be changed, so I've added the ability to do so on build.

Lemme know if this is an acceptable submission, and I'll do the rest of the leg-work to tick all the necessary boxes.